### PR TITLE
Update tailwind peer to accept also v3

### DIFF
--- a/packages/tailwindcss-bg-patterns/package.json
+++ b/packages/tailwindcss-bg-patterns/package.json
@@ -19,6 +19,6 @@
     "tailwindcss": "3.3.2"
   },
   "peerDependencies": {
-    "tailwindcss": "^2"
+    "tailwindcss": ">2"
   }
 }


### PR DESCRIPTION
Current ^2 means technically tailwind v3+ aren't a proper peer to this package.


This resulted in multiple copies of tailwind in production apps:

![image](https://github.com/manawiki/core/assets/84349818/8217f730-83c9-4d02-b3a4-b3e9e52dd3a8)

----

Assuming you want to maintain tailwind v2 compatibility with this package, the proper syntax is ">2"

https://semver.npmjs.com/#syntax-examples